### PR TITLE
Add Set-Cookie to the set of removed headers

### DIFF
--- a/libsoup/soup-cache.c
+++ b/libsoup/soup-cache.c
@@ -295,7 +295,7 @@ remove_headers (const char *name, const char *value, SoupMessageHeaders *headers
 	soup_message_headers_remove (headers, name);
 }
 
-static char *hop_by_hop_headers[] = {"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization", "TE", "Trailer", "Transfer-Encoding", "Upgrade"};
+static char *hop_by_hop_headers[] = {"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization", "TE", "Trailer", "Transfer-Encoding", "Upgrade", "Set-Cookie"};
 
 static void
 copy_end_to_end_headers (SoupMessageHeaders *source, SoupMessageHeaders *destination)


### PR DESCRIPTION
A cache entry should not store the Set-Cookie header,
or it could revive an old cookie on a cache hit.
