### PR TITLE
nls: Add meson option to enable/disable NLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -289,7 +289,9 @@ cdata.set_quoted('GETTEXT_PACKAGE', libsoup_api_name)
 configure_file(output : 'config.h', configuration : cdata)
 
 subdir('libsoup')
-subdir('po')
+if get_option('nls')
+  subdir('po')
+endif
 subdir('examples')
 
 if get_option('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,12 @@ option('krb5_config',
   description : 'Where to look for krb5-config, path points to krb5-config installation (defaultly looking in PATH)'
 )
 
+option('nls',
+  type : 'boolean',
+  value : true,
+  description : 'Build with native language support'
+)
+
 option('ntlm',
   type : 'boolean',
   value : false,


### PR DESCRIPTION
New meson option to enable/disable Native Language Support.
See https://packages.gentoo.org/useflags/nls for motivation.