### PR TITLE
Wrong license?

### DIFF
--- a/README
+++ b/README
@@ -26,4 +26,4 @@ More information (including the libsoup To Do list) is available at
 https://wiki.gnome.org/Projects/libsoup
 
 Licensing:
-libsoup is licensed under the LGPL, see COPYING for more details.
+libsoup is licensed under the GPL, see COPYING for more details.


### PR DESCRIPTION
The info in COPYING seems to be GPL and not LGPL. The LGPL license can be found here: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt